### PR TITLE
Display a helpful list of populated categories on the public profile

### DIFF
--- a/app/Http/Controllers/ItemsController.php
+++ b/app/Http/Controllers/ItemsController.php
@@ -70,8 +70,18 @@ class ItemsController extends Controller
     }
 
 
-    public function showUserHome() {
-        return view('welcome');
+    public function showUserHome(Request $request) {
+        $categoryCount = DB::table('items')
+          ->join('categories', 'items.category_id', '=', 'categories.id')
+          ->where('user_id', '=', $request->selected_account->id)
+          ->select('categories.name', DB::raw('count(*) as total'))
+          ->groupBy('categories.name')
+          ->orderBy('total', 'DESC')
+          ->pluck('total','categories.name')->all();
+
+        $categories = Category::all();
+
+        return view('welcome', ['categoryCounts' => $categoryCount, 'categories' => $categories]);
     }
 
     public function showItemsPage(Request $request, $subdomain, $category = null) {

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -2,6 +2,28 @@
 
 @section('content')
 
+    <!-- Populated Lists -->
+    @if (isset($categories))
+        <div class="row">
+            <div class="col-lg-6 col-lg-offset-3 text-center">
+                <ul class="nav nav-pills" role="tablist">
+                @foreach ($categories as $category)
+                    @if (!empty($categoryCounts[$category->name]))
+                        <li role="presentation"><a class="text-uppercase" href="{{ url('/') }}/{{ $category->slug }}">
+                                <i class="{{ $category->icon }}"></i> {{ $category->name }}
+                                <span class="badge">{{ $categoryCounts[$category->name] }}</span>
+                            </a>
+                        </li>
+                    @else
+                        <li role="presentation" class="disabled">
+                            <a class="text-uppercase" href=""><i class="{{ $category->icon }}"></i> {{ $category->name }}</a>
+                        </li>
+                    @endif
+                @endforeach
+                </ul>
+            </div>
+        </div>
+    @endif
 
     <!-- Contact Section -->
     <section id="contact">


### PR DESCRIPTION
This is intended to fix #11, which happened because I didn't realize I could navigate into each category in the Navbar - my eyes jumped to the Welcome text & interpreted that as meaning everything was private.

This adds a new set of badges below the profile information, with a counter for the number of items that are under each badge.

<img width="790" alt="screen shot 2017-03-19 at 1 13 54 am" src="https://cloud.githubusercontent.com/assets/602491/24079292/863026a6-0c41-11e7-8924-ff800d42591a.png">
